### PR TITLE
fix: install pnpm in workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -47,11 +47,16 @@ jobs:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
+      - name: Enable Corepack
+        if: steps.detect-package-manager.outputs.manager == 'pnpm'
+        run: corepack enable
+
       - name: Setup pnpm
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
         uses: pnpm/action-setup@v2
         with:
           version: 9
+          run_install: false
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- ensure pnpm is available during CI by enabling corepack and skipping auto-install

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f638a0c832eb3473faf61167098